### PR TITLE
chore: ensure importer waits for db

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -54,6 +54,9 @@ services:
     build:
       context: .
       target: importer
+    depends_on:
+      - timescaledb
+    restart: unless-stopped
     environment:
       - DATABASE_URL=postgres://postgres:password@timescaledb:5432/postgres
 


### PR DESCRIPTION
## Summary
- ensure importer waits for TimescaleDB by adding depends_on and restart policy

## Testing
- `cargo test`
- `docker compose up -d importer` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0331aa38832ebb128b5fe9c9e250