### PR TITLE
feat: add analytics database url

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -66,3 +66,4 @@ services:
       - ORIGIN=http://localhost:3000
       - ANALYTICS_ADDRESS=0.0.0.0:4002
       - RUST_LOG=analytics=debug
+      - DATABASE_URL=postgres://postgres:password@timescaledb:5432/postgres


### PR DESCRIPTION
## Summary
- add DATABASE_URL environment variable to analytics service

## Testing
- `docker compose config analytics`
- `docker compose up -d analytics` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0330f130832e831433329626efc3