### PR TITLE
Add timescaledb health dependency for analytics service

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -65,6 +65,9 @@ services:
     build:
       context: .
       target: analytics
+    depends_on:
+      timescaledb:
+        condition: service_healthy
     environment:
       - ORIGIN=http://localhost:3000
       - ANALYTICS_ADDRESS=0.0.0.0:4002


### PR DESCRIPTION
## Summary
- wait for timescaledb health before starting analytics service

## Testing
- `cargo test`
- `docker compose up -d analytics` *(fails: compose command not found/daemon unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb066ce56c832ebdef6a12f423b72c