### PR TITLE
Use Docker service name for database URL

### DIFF
--- a/compose.env
+++ b/compose.env
@@ -1,0 +1,1 @@
+DATABASE_URL=postgres://postgres:password@timescaledb:5432/postgres

--- a/compose.yaml
+++ b/compose.yaml
@@ -64,7 +64,7 @@ services:
         condition: service_healthy
     restart: unless-stopped
     environment:
-      - DATABASE_URL=postgres://postgres:password@timescaledb:5432/postgres
+      - DATABASE_URL=${DATABASE_URL}
 
   analytics:
     image: ghcr.io/slowlydev/f1-dash-analytics:latest
@@ -78,4 +78,4 @@ services:
       - ORIGIN=http://localhost:3000
       - ANALYTICS_ADDRESS=0.0.0.0:4002
       - RUST_LOG=analytics=debug
-      - DATABASE_URL=postgres://postgres:password@timescaledb:5432/postgres
+      - DATABASE_URL=${DATABASE_URL}


### PR DESCRIPTION
## Summary
- add compose.env with DATABASE_URL using the timescaledb service
- reference DATABASE_URL from env file in importer and analytics services

## Testing
- `cargo test`
- `docker compose --env-file compose.env up -d importer analytics` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb08db2660832e90dced9ef1f939d0